### PR TITLE
Ensure error codes don't change over time

### DIFF
--- a/elusiv-warden-network/Cargo.lock
+++ b/elusiv-warden-network/Cargo.lock
@@ -1020,6 +1020,7 @@ dependencies = [
  "solana-program-test",
  "solana-sdk",
  "spl-token",
+ "strum",
 ]
 
 [[package]]

--- a/elusiv-warden-network/Cargo.toml
+++ b/elusiv-warden-network/Cargo.toml
@@ -51,6 +51,7 @@ elusiv-test = { path = "shared/elusiv-test" }
 elusiv-warden-network = { path = ".", features = ["elusiv-client", "test-elusiv", "logging"] }
 solana-program-test = "1.10"
 solana-sdk = "1.10"
+strum = { version = "0.24", features = ["derive"] }
 mock-program = { path = "shared/elusiv-test/mock-program" }
 
 [profile.test]

--- a/elusiv-warden-network/src/error.rs
+++ b/elusiv-warden-network/src/error.rs
@@ -1,6 +1,7 @@
 use solana_program::program_error::ProgramError;
 use std::fmt;
 
+#[cfg_attr(test, derive(strum::EnumIter))]
 #[derive(Copy, Clone, Debug)]
 pub enum ElusivWardenNetworkError {
     InvalidSignature,
@@ -25,5 +26,36 @@ impl From<ElusivWardenNetworkError> for ProgramError {
 impl fmt::Display for ElusivWardenNetworkError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", *self as u32)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use strum::IntoEnumIterator;
+
+    #[test]
+    fn test_error_codes_never_change() {
+        // If this test fails at compile time, just add the variant to the `match` block below.
+        // If this test fails at runtime, the probable cause is a reorg.
+        // Reorganizing the enum will lead to changes in the resulting error codes, making it easy
+        // to mistake one error for another.
+        for variant in ElusivWardenNetworkError::iter() {
+            use ElusivWardenNetworkError::*;
+            let expected_code = match variant {
+                InvalidSignature => 0,
+                InvalidInstructionData => 1,
+                InvalidSigner => 2,
+                WardenRegistrationError => 3,
+                ProposalError => 4,
+                VotingError => 5,
+                StatsError => 6,
+                TimestampError => 7,
+                Overflow => 8,
+                Underflow => 9,
+            };
+
+            assert_eq!(variant as u32, expected_code);
+        }
     }
 }


### PR DESCRIPTION
Add a unit test so we're aware if any code<->error association was changed.