### PR TITLE
Add the `no-entrypoint` feature for mock-program

### DIFF
--- a/elusiv-warden-network/Cargo.toml
+++ b/elusiv-warden-network/Cargo.toml
@@ -51,7 +51,7 @@ elusiv-test = { path = "shared/elusiv-test" }
 elusiv-warden-network = { path = ".", features = ["elusiv-client", "test-elusiv", "logging"] }
 solana-program-test = "1.10"
 solana-sdk = "1.10"
-mock-program = { path = "shared/elusiv-test/mock-program" }
+mock-program = { path = "shared/elusiv-test/mock-program", features = ["no-entrypoint"] }
 
 [profile.test]
 opt-level = 2

--- a/shared/elusiv-test/mock-program/Cargo.toml
+++ b/shared/elusiv-test/mock-program/Cargo.toml
@@ -10,3 +10,6 @@ solana-program = "1.10"
 [lib]
 name = "mock_program"
 crate-type = ["cdylib", "lib"]
+
+[features]
+no-entrypoint = []

--- a/shared/elusiv-test/mock-program/src/lib.rs
+++ b/shared/elusiv-test/mock-program/src/lib.rs
@@ -1,5 +1,6 @@
 use solana_program::{pubkey::Pubkey, account_info::AccountInfo, entrypoint::ProgramResult};
 
+#[cfg(not(feature = "no-entrypoint"))]
 solana_program::entrypoint!(process_instruction);
 
 pub fn process_instruction(_: &Pubkey, _: &[AccountInfo], _: &[u8]) -> ProgramResult {


### PR DESCRIPTION
Fixes the "duplicate entrypoint" issues