### PR TITLE
Adjust `docker_test.sh` to match the changes made to the `build` crate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,3 @@ ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 # Use a temporary crate to install cargo-test-bpf
 RUN cargo new temp && cd temp \
   && cargo-test-bpf && cd .. && rm -R temp
-# We may want to mount the sources instead, or have these properly built in the image. We'll see along with more use.
-COPY . .

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Execute the tests with:
 $ sh build.sh test --test-kind <unit|integration|...> --target <program-name>
 ```
 
+### Using Docker
+Testing can be performed in a Docker container using `./docker_test.sh`. Running this will result in the creation of an `elusiv-dev` Docker image as well as a few cache volumes. 
+
 ### Program interaction
 In order to easily interact with the program from a Rust client, import a program library with the `elusiv-client` feature enabled.
 This results in access to all instruction-generation functions located in each program-crate's `instructions` module.

--- a/docker_test.sh
+++ b/docker_test.sh
@@ -13,14 +13,15 @@ docker volume create elusiv_warden_network_target
 docker build -t elusiv-dev:latest .
 
 docker run -it --rm \
-  -v $(readlink -f $SSH_AUTH_SOCK):/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent \
   --mount type=volume,source=registry,target=/usr/local/cargo/registry \
   --mount type=volume,source=git,target=/usr/local/cargo/git \
   --mount type=volume,source=build_target,target=/workdir/build/target \
   --mount type=volume,source=elusiv_target,target=/workdir/elusiv/target \
   --mount type=volume,source=elusiv_warden_network_target,target=/workdir/elusiv-warden-network/target \
+  -v ./:/workdir \
   -e RUST_BACKTRACE=1 \
-  elusiv-dev sh -c 'sh ./build.sh test --unit elusiv \
-  && sh ./build.sh test --integration elusiv \
-  && sh ./build.sh test --unit elusiv-warden-network \
-  && sh ./build.sh test --integration elusiv-warden-network'
+  elusiv-dev sh -c '
+  sh ./build.sh test --test-kind unit --target elusiv \
+  && sh ./build.sh test --test-kind integration --target elusiv \
+  && sh ./build.sh test --test-kind unit --target elusiv-warden-network \
+  && sh ./build.sh test --test-kind integration --target elusiv-warden-network'

--- a/elusiv-warden-network/src/entrypoint.rs
+++ b/elusiv-warden-network/src/entrypoint.rs
@@ -21,7 +21,7 @@ security_txt! {
     policy: "https://github.com/elusiv-privacy/elusiv/blob/main/SECURITY.md",
     preferred_languages: "en",
     source_code: "https://github.com/elusiv-privacy/elusiv/blob/elusiv-warden-network",
-    source_revision: default_env!("GITHUB_SHA", ""),
+    source_revision: default_env!("GITHUB_SHA", "")
 }
 
 #[cfg(not(tarpaulin_include))]


### PR DESCRIPTION
Actually mount the sources instead of copying them into the image 
^ this will keep the `Cargo.lock` file up to date on the host FS 

Mention this script in the `README.md`